### PR TITLE
Fix typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![](https://badge.imagelayers.io/yavin/alpine-php-fpm:latest.svg)](https://imagelayers.io/?images=yavin/alpine-php-fpm:latest)
 
 Tags:
-* `latest`, `7.0` [Dokerfile](https://github.com/Yavin/docker-alpine-php-fpm/blob/master/Dockerfile)
-* `5.6` [Dokerfile](https://github.com/Yavin/docker-alpine-php-fpm/blob/5.6/Dockerfile)
+* `latest`, `7.0` [Dockerfile](https://github.com/Yavin/docker-alpine-php-fpm/blob/master/Dockerfile)
+* `5.6` [Dockerfile](https://github.com/Yavin/docker-alpine-php-fpm/blob/5.6/Dockerfile)
 
 Image for php-fpm. It is based on Alpine linux and thats why it is very small (~65MB). Included extensions are required for Symfony framework 3+, that's why it should also work with other applications.
 * PHP 7.0.7


### PR DESCRIPTION
There was a typo in the Readme that had to be fixed `Dokerfile -> Dockerfile`

Signed-off-by: Minca Daniel Andrei dminca@marketstheworld.com
